### PR TITLE
Fixed submodule clone problems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "branchbuildbot/src/pyleaf"]
 	path = branchbuildbot/src/pyleaf
-	url = git@github.com:AcaciaLinux/pyleaf.git
+	url = https://github.com/AcaciaLinux/pyleaf.git
+	shallow = true


### PR DESCRIPTION
Submodules were added using the `git` protocol instead of `https`, this lead to the clone failing